### PR TITLE
LD flags fix for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LIBS	= -lusb-1.0
 PREFIX ?= usr/local
 
 ifdef LIBUSB
-CFLAGS	+= -I$(LIBUSB)/include
+CFLAGS	+= -I$(LIBUSB)/include -L$(LIBUSB)/lib
 LDFLAGS	+= -L$(LIBUSB)/lib
 endif
 
@@ -94,4 +94,3 @@ uninstall:
 	@echo $(DL)    VALUE "Translation", 0x409, 1252 $(DL)>>$@
 	@echo $(DL)  END $(DL)>>$@
 	@echo $(DL)END $(DL)>>$@
-


### PR DESCRIPTION
This is when compiling with OSX:

```
$ > LIBUSB=/usr/local make
gcc -O2 -W -Wall -I/usr/local/include rkcrc.c -o rkcrc  -lusb-1.0
ld: library not found for -lusb-1.0
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [rkcrc] Error 1
```
It does not include the Library path.

This is a hack, don't know a possible fix.