### PR TITLE
build: use pkg-config to find libusb-1.0 if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,21 @@ CC	= $(CROSSPREFIX)gcc
 LD	= $(CC)
 CFLAGS	= -O2 -W -Wall
 LDFLAGS	=
-LIBS	= -lusb-1.0
 PREFIX ?= usr/local
 
-ifdef LIBUSB
+PKGCONFIG ?= $(shell pkg-config --exists libusb-1.0 && echo 1)
+
+ifeq ($(PKGCONFIG),1)
+CFLAGS += $(shell pkg-config --cflags libusb-1.0)
+LDFLAGS += $(shell pkg-config --libs libusb-1.0)
+else ifdef LIBUSB
 CFLAGS	+= -I$(LIBUSB)/include
 LDFLAGS	+= -L$(LIBUSB)/lib
+else
+CFLAGS	+= -I/usr/include/libusb-1.0
+LDFLAGS += -lusb-1.0
 endif
+
 
 MACH	= $(shell $(CC) -dumpmachine)
 ifeq ($(findstring mingw,$(MACH)),mingw)
@@ -45,7 +53,7 @@ SCRIPTS = rkunsign rkparametersblock rkmisc rkpad rkparameters
 all: $(PROGS) $(SCRIPTS)
 
 %$(BINEXT): %.c $(RESFILE)
-	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS) $(LIBS)
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 install: $(PROGS) $(SCRIPTS)
 	install -d -m 0755 $(DESTDIR)/$(PREFIX)/bin

--- a/rkflashtool.c
+++ b/rkflashtool.c
@@ -32,7 +32,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 
 /* hack to set binary mode for stdin / stdout on Windows */
 #ifdef _WIN32


### PR DESCRIPTION
Use pkg-config if available.
Fixes FTBS on kfreebsd.