### PR TITLE
Add missing product IDs for 3328 and 3399

### DIFF
--- a/rkflashtool.c
+++ b/rkflashtool.c
@@ -115,6 +115,7 @@ static const struct t_pid {
     { 0x320a, "RK3288" },
     { 0x320b, "RK322X" }, // Both RK3228 and RK3229
     { 0x330a, "RK3368" },
+    { 0x330c, "RK3399" },
     { 0, "" },
 };
 

--- a/rkflashtool.c
+++ b/rkflashtool.c
@@ -114,6 +114,7 @@ static const struct t_pid {
     { 0x310d, "RK3126" },
     { 0x320a, "RK3288" },
     { 0x320b, "RK322X" }, // Both RK3228 and RK3229
+    { 0x320c, "RK3328" },
     { 0x330a, "RK3368" },
     { 0x330c, "RK3399" },
     { 0, "" },


### PR DESCRIPTION
2 trivial patches, both tested, and reflecting information from http://opensource.rock-chips.com/wiki_Rockusb