### PR TITLE
Add RK3528 chip

### DIFF
--- a/rkflashtool.c
+++ b/rkflashtool.c
@@ -117,6 +117,7 @@ static const struct t_pid {
     { 0x320c, "RK3328" },
     { 0x330a, "RK3368" },
     { 0x330c, "RK3399" },
+    { 0x350c, "RK3528" },
     { 0, "" },
 };
 


### PR DESCRIPTION
Add RK3528 chip found in the H96 MAX M1 device and a similar ones. Reported [here](https://habr.com/ru/companies/ruvds/articles/766422/).